### PR TITLE
Make some small style/effciency improvements

### DIFF
--- a/src/char-values.jl
+++ b/src/char-values.jl
@@ -25,11 +25,11 @@ function charλ(q::Real, nu_::Real; k::UnitRange=1:1) # reduced = true
     D =  (0.24 + 0.0214*nu0)/(1 + 0.059*nu0)
     N = ceil(Int, (nu0 + 2 + C*abs(q)^D)/2) # matrix size is 2N+1
 
-    (two, q2, nu2) = float.(promote(2, q, nu))
+    (two, q2, nu2) = float.(promote(2, q, nu)) # d0 and d1 must be of the same type
     d0 = (two .* (-N:N) .- nu2).^2
-    d1 = q2 .* ones(eltype(q2), 2 * N)
+    d1 = fill(q2, 2 * N)
     A = SymTridiagonal(d0, d1)
-    a = eigvals(A, k)
+    a = eigvals!(A, k)
     return a
 end
 


### PR DESCRIPTION
* Use mutating eigvals! to avoid an allocation.
* Add comment on reason for promotion.
* Use `fill` rather than `ones`. This is cleaner and more efficient.

Although these changes include improvements in efficiency, I found no measurable difference
in run time. It's more a question of best practices. Eg, you should avoid an allocation
if it doesn't make the code less readable.

I meant to include these in the previous PR, but they escaped somehow.
