### PR TITLE
Addition of the Mathieu even and odd functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,23 @@
 
 Julia package for Mathieu functions.
 
+## Update:
+The updates to the old repo consist of the addition of the actual Mathieu functions
+themselves in addition to the characteristic value calculations. This implements the code
+I have described in my own [Mathieu function
+package](https://github.com/mahdi-sasar/Mathieu-Functions). I decided to add the code
+here, since the current nice package is already installed in the Julia general registry.
+My addition uses the characteristic values provided by the original code and uses the
+well-known algorithms found in the brilliant textbook of Morse & Feshbach
+and the [*Digital Library of Mathematical Functions*](https://dlmf.nist.gov/28.2). Both
+are essentially the same really. The great efficiency of the Julia language gave rise to a
+pretty handy tool here that helped me greatly in my own calculations. I hope it can aid
+you in your projects as well!
+The functions are $ce(n, q, x)$ (Mathieu even function) and $se(n, q, x)$ (Mathieu odd
+function). The $n$ is the index of the Mathieu function and the input x is a range
+(e.g. $\texttt{x = range(-pi, pi, 500)}$). Plots can be performed with commands like
+$\texttt{plot(x, ce(n, q, x))}$, using the Plots package.
+
 Mathieu functions are the eigenvalues and eigenfunction of *Mathieu's
 equation* (for more details, see [NIST's Digital Library of
 Mathematical Functions](http://dlmf.nist.gov/28)).

--- a/README.md
+++ b/README.md
@@ -12,21 +12,22 @@
 Julia package for Mathieu functions.
 
 ## Update:
-The updates to the old repo consist of the addition of the actual Mathieu functions
-themselves in addition to the characteristic value calculations. This implements the code
-I have described in my own [Mathieu function
-package](https://github.com/mahdi-sasar/Mathieu-Functions). I decided to add the code
-here, since the current nice package is already installed in the Julia general registry.
-My addition uses the characteristic values provided by the original code and uses the
-well-known algorithms found in the brilliant textbook of Morse & Feshbach
-and the [*Digital Library of Mathematical Functions*](https://dlmf.nist.gov/28.2). Both
-are essentially the same really. The great efficiency of the Julia language gave rise to a
-pretty handy tool here that helped me greatly in my own calculations. I hope it can aid
-you in your projects as well!
-The functions are $ce(n, q, x)$ (Mathieu even function) and $se(n, q, x)$ (Mathieu odd
-function). The $n$ is the index of the Mathieu function and the input x is a range
-(e.g. $\texttt{x = range(-pi, pi, 500)}$). Plots can be performed with commands like
-$\texttt{plot(x, ce(n, q, x))}$, using the Plots package.
+The updates to the old repository include the addition of the actual Mathieu functions
+themselves, in addition to the calculations for the characteristic values. The code that
+has been added here is also described in my own repository [Mathieu function
+package](https://github.com/mahdi-sasar/Mathieu-Functions). I opted to incorporate my
+code here, given that the package here is already installed in the Julia general
+registry. In this contribution the characteristic values are computed by the original
+code and employs the well-known algorithms featured in Morse & Feshbach's esteemed
+textbook, as well as the [*Digital Library of Mathematical
+Functions*](https://dlmf.nist.gov/28.2). Both sources offer essentially the same thing.
+
+The functions available are `ce(n, q, x)` for the Mathieu even function and `se(n, q, x)`
+for the Mathieu odd function. Here, `n` represents the index of the Mathieu function, and
+`x` is a range (e.g. `x = range(-pi, pi, length=500)`). Plotting can be
+easily done using commands like `plot(x, ce(n, q, x))`, with the Plots package in Julia.
+
+
 
 Mathieu functions are the eigenvalues and eigenfunction of *Mathieu's
 equation* (for more details, see [NIST's Digital Library of

--- a/src/MathieuFunctions.jl
+++ b/src/MathieuFunctions.jl
@@ -1,6 +1,6 @@
 module MathieuFunctions
 using LinearAlgebra
 
-  include("char-values.jl")
+include("char-values.jl")
 
 end

--- a/src/char-values.jl
+++ b/src/char-values.jl
@@ -1,6 +1,8 @@
 export charλ,
        charA,
-       charB
+    charB,
+    ce,
+    se
 """
 charλ(q,ν,k)
 
@@ -96,4 +98,98 @@ function charB(q::Real; k::UnitRange=1:1)
         b[io] = charλ(abs(q),1.0,k = (k .+ 1))[io]
     end
     return b
+end
+
+export ce,
+       se
+
+#Mathieu cosine function:
+function ce(m::Int64, q::Real, x::AbstractVector{Float64})
+    accuracy = 0.00001
+    if m%2 == 0
+        a = charA(q, k=m:m)[1]
+        A = [0., 1., 0., a/q, 0., ((a-4.)*a/(q*q))-2., 0.]
+        i = 8
+        #Normalization as each new coefficient is computed:
+        N = 2*A[2]^2 + sum(A[4:end].^2)
+        A = A ./N
+        while (abs(A[i-2]/A[2])>accuracy)
+            push!(A, ((a-(i-4.)*(i-4.))/q)*A[i-2]- A[i-4])
+            push!(A, 0.)
+            N = 2*A[2]^2 + sum(A[4:end].^2)
+            A = A ./N
+            i += 2
+        end
+        t = zeros(length(x))
+        for j in 2:length(A)
+            t += A[j]*cos.((j-2)*x)
+        end
+        return t
+    end
+    if m%2 == 1
+        a = charA(q, k=m:m)[1]
+        A = [1., 0., (a-q-1.)/q, 0., ((a-9.)/q)*((a-q-1.)/q)-1., 0., ((a-25.)/q)*(((a-9.)/q)*((a-q-1.)/q)-1.)-(a-q-1.)/q, 0.]
+        i = 9
+        #Normalization as each new coefficient is computed:
+        N = sum(A[1:end].^2)
+        A = A ./N
+        while (abs(A[i-2]/A[1])>accuracy)
+            push!(A, ((a-(i-2)*(i-2))/q)*A[i-2] - A[i-4])
+            push!(A, 0.)
+            N = sum(A[1:end].^2)
+            A = A ./N
+            i += 2
+        end
+        t = zeros(length(x))
+        for j in 1:length(A)
+            t += A[j]*cos.((j)*x)
+        end
+        return t
+    end
+end
+
+#Mathieu sine function:
+function se(m::Int64, q::Real, x::AbstractVector{Float64})
+    accuracy = 0.00001
+    if m%2 == 0
+        a = charB(q, k=m:m)[1]
+        B = [0., 1., 0., (a-4.)/q, 0.]
+        i = 6
+        #Normalization as each new coefficient is computed:
+        N = sum(B[2:end].^2)
+        B = B ./N
+        while (abs(B[i-2]/B[2])>accuracy)
+            push!(B, ((a-(i-2.)*(i-2.))/q)*B[i-2]- B[i-4])
+            push!(B, 0.)
+            N = sum(B[2:end].^2)
+            B = B ./N
+            i += 2
+        end
+        t = zeros(length(x))
+        for j in 2:length(B)
+            t += B[j]*sin.((j)*x)
+        end
+        return t
+    end
+    if m%2 == 1
+        a = charB(q, k=m:m)[1]
+        B = [1., 0., (a+q-1.)/q, 0.]
+        i = 5
+        #Normalization as each new coefficient is computed:
+        N = sum(B[1:end].^2)
+        B = B ./N
+        while (abs(B[i-2]/B[1])>accuracy)
+            push!(B, ((a-(i-2)*(i-2))/q)*B[i-2] - B[i-4])
+            push!(B, 0.)
+            N = sum(B[1:end].^2)
+            B = B ./N
+            i += 2
+        end
+        println(B)
+        t = zeros(length(x))
+        for j in 1:length(B)
+            t += B[j]*sin.((j)*x)
+        end
+        return t
+    end
 end

--- a/src/char-values.jl
+++ b/src/char-values.jl
@@ -100,9 +100,6 @@ function charB(q::Real; k::UnitRange=1:1)
     return b
 end
 
-export ce,
-       se
-
 #Mathieu cosine function:
 function ce(m::Int64, q::Real, x::AbstractVector{Float64})
     accuracy = 0.00001
@@ -112,12 +109,12 @@ function ce(m::Int64, q::Real, x::AbstractVector{Float64})
         i = 8
         #Normalization as each new coefficient is computed:
         N = 2*A[2]^2 + sum(A[4:end].^2)
-        A = A ./N
-        while (abs(A[i-2]/A[2])>accuracy)
+        A = A ./sqrt(N)
+        while (abs(A[i-2])>accuracy)
             push!(A, ((a-(i-4.)*(i-4.))/q)*A[i-2]- A[i-4])
             push!(A, 0.)
             N = 2*A[2]^2 + sum(A[4:end].^2)
-            A = A ./N
+            A = A ./sqrt(N)
             i += 2
         end
         t = zeros(length(x))
@@ -132,12 +129,12 @@ function ce(m::Int64, q::Real, x::AbstractVector{Float64})
         i = 9
         #Normalization as each new coefficient is computed:
         N = sum(A[1:end].^2)
-        A = A ./N
-        while (abs(A[i-2]/A[1])>accuracy)
+        A = A ./sqrt(N)
+        while (abs(A[i-2])>accuracy)
             push!(A, ((a-(i-2)*(i-2))/q)*A[i-2] - A[i-4])
             push!(A, 0.)
             N = sum(A[1:end].^2)
-            A = A ./N
+            A = A ./sqrt(N)
             i += 2
         end
         t = zeros(length(x))
@@ -157,12 +154,12 @@ function se(m::Int64, q::Real, x::AbstractVector{Float64})
         i = 6
         #Normalization as each new coefficient is computed:
         N = sum(B[2:end].^2)
-        B = B ./N
-        while (abs(B[i-2]/B[2])>accuracy)
+        B = B ./sqrt(N)
+        while (abs(B[i-2])>accuracy)
             push!(B, ((a-(i-2.)*(i-2.))/q)*B[i-2]- B[i-4])
             push!(B, 0.)
             N = sum(B[2:end].^2)
-            B = B ./N
+            B = B ./sqrt(N)
             i += 2
         end
         t = zeros(length(x))
@@ -177,15 +174,14 @@ function se(m::Int64, q::Real, x::AbstractVector{Float64})
         i = 5
         #Normalization as each new coefficient is computed:
         N = sum(B[1:end].^2)
-        B = B ./N
-        while (abs(B[i-2]/B[1])>accuracy)
+        B = B ./sqrt(N)
+        while (abs(B[i-2])>accuracy)
             push!(B, ((a-(i-2)*(i-2))/q)*B[i-2] - B[i-4])
             push!(B, 0.)
             N = sum(B[1:end].^2)
-            B = B ./N
+            B = B ./sqrt(N)
             i += 2
         end
-        println(B)
         t = zeros(length(x))
         for j in 1:length(B)
             t += B[j]*sin.((j)*x)


### PR DESCRIPTION
Hi everyone.
The old repository here only allowed for the calculation of the characteristic values of the Mathieu functions. I decided to add the actual definitions of the Mathieu sine and cosine functions using the Fourier series expansion of these functions that is available in many textbooks.
Hope this is useful and can aid others as well. I personally use them extensively now for some quantum mechanical studies where using Mathieu functions as basis sets is computationally beneficial. 